### PR TITLE
Fixing travis failing (Likely because bootstrap.py is pulling too new zc.buildout)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 
 install:
   - $(which echo) -e "[buildout]\nextends = buildout.d/travis.cfg" > buildout.cfg
-  - python bootstrap.py
+  - python bootstrap.py --version 1.6.0
   - bin/buildout
 
 script:


### PR DESCRIPTION
...ing pulled by default doesn't work
